### PR TITLE
[BUGFIX] Avoid duplicated events in one table stricly

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -128,6 +128,7 @@ CREATE TABLE tx_fourallportal_domain_model_event (
 	deleted smallint(5) unsigned DEFAULT '0' NOT NULL,
 
 	PRIMARY KEY (uid),
+	UNIQUE KEY event_id (event_id),
 	KEY parent (pid),
 	KEY event_type (event_type),
 	KEY object_id (object_id),


### PR DESCRIPTION
# Description

It was discovered that on our TYPO3 installation events are duplicated multiple times. 

The issue was that full sync scheduler task ("fourallportal:sync --sync --full-sync" - the one which truncates events table and then downloads all events into that table again) sometimes was running too slow and it was looking like it's stuck. Thus some of our administrators was canceling run of that task to start this again in few min. 

However TYPO3 scheduler can not kill php process that actually runs the task so when you cancel task in scheduler it will just unmark it as "running" but php process will be still alive and will keep storing events in the table. Thus, when our administrator runs that task again then both (old php process and new one which was just created by new run of the task) were syncing the same events and because of that some of those events were duplicated in the table.

This patch applies UNIQUE KEY to event_id column, which means that there will be no chance to store duplicated event if original already created. This will bring some strictness to events table and will have also some benefit in performance because one event will be processed only once and not twice or more in case of duplicates.


## Test instruction 1

- [ ] Apply this patch
- [ ] Run typo3cms database:updateschema TYPO3 console command or do this by Install Tool to update db schema and apply UNIQUE KEY
- [ ] Now edit tx_fourallportal_domain_model_event table via any SQL client (e.g. Sequel Pro) and try to create two records with the same event_id column value

### Expectation

- [ ] You will be able to create only one record with the same column_id value
