### PR TITLE
[BUGFIX] Allow truncating of events table in full sync task when in Scheduler context

### DIFF
--- a/Classes/Domain/Dto/SyncParameters.php
+++ b/Classes/Domain/Dto/SyncParameters.php
@@ -113,7 +113,7 @@ class SyncParameters
 
     public function setExclude($exclude): self
     {
-        if ($exclude === null) {
+        if ($exclude === null || $exclude === '') {
             $this->exclude = [];
         } else {
             $this->exclude = is_array($exclude) ? $exclude : explode(',', (string) $exclude);


### PR DESCRIPTION
# Description

It was discovered that when you run full sync task ("fourallportal:sync --sync --full-sync") from Scheduler context and not via direct command in CLI then events table will not be truncated before resyncing all the events.

Here is scheduler task:
<img width="638" alt="image" src="https://user-images.githubusercontent.com/50489886/125748777-89669573-2490-42a7-aae3-6f3f6d4b27ff.png">

It is not truncated because of unexpected value in $exclude variable here:
<img width="882" alt="image" src="https://user-images.githubusercontent.com/50489886/125699572-0bb11a67-52ad-4801-a14b-98f7735b44c5.png">

$exclude variable in EventExecutionService::performSync is actually not empty when in scheduler context as you can see on the screenshot above. So it does not go inside of the if statement.

However if you can see on the settings of scheduler task (screen on the top) "exclude" param is empty.

That's all is because in FourallportalCommandController::syncCommand $exclude argument (in method signature) will be just empty string - "" and not null:
<img width="886" alt="image" src="https://user-images.githubusercontent.com/50489886/125699328-f05aefea-3065-438e-b68f-ee2687eecea5.png">

because this is how scheduler understands command interface as we have string type declared in the syncCommand method, so in other places where we have check on null we also need to take care of empty string.

but right now as in SyncParameters::setExclude we have $exclude empty string and not null we will have SyncParameters ::exclude set to not empty array value but something like this -> `[ 0 => '']`, 

<img width="894" alt="image" src="https://user-images.githubusercontent.com/50489886/125699485-d4e0356a-0646-49da-b47a-eaaca40b40d4.png">

thus TRUNCATE of events table will not happen in EventExecutionService::performSync. Because `empty([ 0 => ''])` === false.

<img width="882" alt="image" src="https://user-images.githubusercontent.com/50489886/125699572-0bb11a67-52ad-4801-a14b-98f7735b44c5.png">

Now have a look on the change in this patch and you will understand the logic.

This patch takes care of SyncParameters::setExclude and when it is empty string OR is just null then in SyncParameters::setExclude "exclude" will be set to empty array "[]" thus in EventExecutionService::performSync events table wil be truncated.

=================================================================

When you run this command through CLI "fourallportal:sync --sync --full-sync" you do not specify exclude param at all which means that $exclude argument in FourallportalCommandController::syncCommand will be null and $exclude variable in EventExecutionService::performSync is then empty which allows truncating.


## Test instruction 1

- [ ] Apply this patch
- [ ] Run full sync task from TYPO3 Scheduler context (with not specified exclude field). Take settings for scheduler task from the image on the top of the description
- [ ] Activate it and deactivate any other scheduler tasks, and run this command: `typo3cms scheduler:run`
- [ ] Wait until it finishes 

### Expectation

- [ ] tx_fourallportal_domain_model_event table was truncated each time you run full sync scheduler task. 
- [ ] you every time have the same amount of records in tx_fourallportal_domain_model_event table after each run of the task.